### PR TITLE
Queries on the output of csv_to_avro.py

### DIFF
--- a/acoustic/csv_to_avro/src/examples.sql
+++ b/acoustic/csv_to_avro/src/examples.sql
@@ -1,0 +1,17 @@
+-- Gallery of exploratory queries
+
+-- Per-species quantiles of hourly detection counts
+SELECT
+    bird,
+    APPROX_QUANTILES(detection_count, 10) hourly_count_quantiles
+FROM comb.prediction_stats_hourly
+GROUP BY 1 ORDER BY 1;
+
+-- Per-species hourly detections counts sorted by count
+SELECT
+  bird,
+  detection_count,
+  hour_utc
+FROM comb.prediction_stats_hourly
+WHERE bird != 'unknown'
+ORDER BY detection_count DESC LIMIT 1000;

--- a/acoustic/csv_to_avro/src/prediction_stats_hourly.sql
+++ b/acoustic/csv_to_avro/src/prediction_stats_hourly.sql
@@ -1,0 +1,21 @@
+-- Hourly rollup of dense logits
+--
+-- This query computes statistics of the logits grouped by species code and hour
+-- for subsequent queryies where a flat table with (species_code, score) columns
+-- may be convenient.
+--
+-- The `predictions` table from which this query selects is an import of the
+-- output of csv_to_avro.py, without --min_logit or --codes_to_exclude flags
+-- set.
+
+SELECT
+    l.key AS bird,
+    TIMESTAMP_TRUNC(begin_timestamp_millis, HOUR) AS hour_utc,
+    SUM(CAST(l.value > 0 AS INT64)) AS detection_count,
+    MAX(l.value) AS max_logit,
+    AVG(l.value) AS mean_logit,
+    AVG(1 / (1 + EXP(-l.value))) AS max_probability,
+    AVG(1 / (1 + EXP(-l.value))) AS mean_probability
+FROM comb.predictions,
+UNNEST(logits) AS l
+GROUP BY bird, hour_utc;

--- a/acoustic/csv_to_avro/src/yearly_counts.sql
+++ b/acoustic/csv_to_avro/src/yearly_counts.sql
@@ -1,0 +1,19 @@
+-- Query used to materialize yearly_counts
+--
+-- yearly_counts is the data source for the Data Studio map visualization.
+--
+-- The `predictions` table from which this query selects is an import of the
+-- output of csv_to_avro.py, without --min_logit or --codes_to_exclude flags
+-- set.
+
+SELECT
+    l.key AS bird,
+    point.point_number AS point,
+    ANY_VALUE(point.latitude) AS latitude,
+    ANY_VALUE(point.longitude) AS longitude,
+    EXTRACT(YEAR FROM begin_timestamp_millis) AS year,
+    SUM(CAST(l.value > 0 AS INT64)) AS detection_count,
+    MAX(l.value) AS max_logit
+FROM `comb.predictions_ge_-1`,
+UNNEST(logits) AS l
+GROUP BY bird, point, year;


### PR DESCRIPTION
This change contains rollup queries to materialize useful summarizations
at longer time scales to export or make subsequent queries cheaper or
more convenient.

It also contains a few illustrative example queries in examples.sql.