### PR TITLE
3 scripts to setup data, run JAGS model, and explore output

### DIFF
--- a/models/src/BACI_EDA.R
+++ b/models/src/BACI_EDA.R
@@ -1,0 +1,321 @@
+load("models/output/BACIdata.RData")
+
+# Occurrence covariates ---------------------------------------------------
+
+### Year effect -------------------------------------------------------------
+
+
+year <- out[97:144,]
+year$spp <- spp
+
+ggplot(year) +
+  geom_point(aes(x=reorder(spp,-mean), y=mean, color=overlap0)) +
+  geom_errorbar(aes(x=reorder(spp,-mean), ymin=`2.5%`, ymax=`97.5%`, color=overlap0)) +
+  geom_linerange(size=2,aes(x=reorder(spp,-mean), ymin=`25%`, ymax=`75%`, color=overlap0)) +
+  geom_hline(yintercept = 0) +
+  labs(y="posterior estimate of year effect", x = "species code", title="Effect of survey year on occurrence") +
+  theme_classic() +
+  scale_color_manual(values=wes_palette("BottleRocket1", n = 2)) +
+  theme(legend.position = "none", axis.text.x = element_text(angle = 50,hjust=1))
+
+
+### Cover effect ------------------------------------------------------------
+
+
+cover <- out[145:192,]
+cover$spp <- spp
+ggplot(cover) +
+  geom_point(aes(x=reorder(spp, -mean), y=mean, color=overlap0)) +
+  geom_errorbar(aes(x=reorder(spp, -mean), ymin=`2.5%`, ymax=`97.5%`, color=overlap0)) +
+  geom_linerange(size=2,aes(x=reorder(spp,-mean), ymin=`25%`, ymax=`75%`, color=overlap0)) +
+  geom_hline(yintercept = 0) +
+  labs(y="posterior estimate of Canopy Cover effect", x = "species code", title="Effect of canopy cover on occurrence") +
+  theme_classic() +
+  scale_color_manual(values=wes_palette("BottleRocket1", n = 2)) +
+  theme(legend.position = "none", axis.text.x = element_text(angle = 50,hjust=1))
+
+
+### Large Tree effect -------------------------------------------------------
+
+
+
+trees <- out[193:240,]
+trees$spp <- spp
+
+# trees %>% filter(spp=="BBWO" | spp=="NOFL" | spp=="MOUQ" | spp=="WETA" |spp=="OSFL" | spp=="WHWO" | spp=="STJA" | spp=="SOGR" | spp=="WEWP" | spp=="HAWO" | spp=="SPTO" | spp=="BHGR" | spp=="DUFL" | spp=="FOSP" | spp=="HEWA" | spp=="AUWA" | spp=="HETH" | spp=="GCKI") %>%
+ggplot(trees) +
+  geom_point(aes(x=reorder(spp,-mean), y=mean, color=overlap0)) +
+  geom_errorbar(aes(x=reorder(spp,-mean), ymin=`2.5%`, ymax=`97.5%`, color=overlap0)) +
+  geom_linerange(size=2,aes(x=reorder(spp,-mean), ymin=`25%`, ymax=`75%`, color=overlap0)) +
+  geom_hline(yintercept = 0) +
+  labs(y="posterior estimate of Tree Height effect", x = "species code", title="Effect of large trees on occurrence") +
+  theme_classic() +
+  scale_color_manual(values=wes_palette("BottleRocket1", n = 2)) +
+  theme(legend.position = "none", axis.text.x = element_text(angle = 50,hjust=1))
+
+tree.spp <- trees %>% filter(overlap0==0)
+
+
+### Fire effect (b0After - b0Before) ----------------------------------------
+
+
+
+fire.fx <- out[289:336,]
+fire.fx$spp <- spp
+
+# fire.fx %>% filter(spp %in% tree.spp$spp) %>%
+#   mutate(updown = ifelse(mean>0,"up","down")) %>%
+ggplot(fire.fx) +
+  geom_point(aes(x=reorder(spp,-mean), y=mean, color=overlap0)) +
+  geom_errorbar(aes(x=reorder(spp,-mean), ymin=`2.5%`, ymax=`97.5%`, color=overlap0)) +
+  geom_linerange(size=2,aes(x=reorder(spp,-mean), ymin=`25%`, ymax=`75%`, color=overlap0)) +
+  geom_hline(yintercept = 0) +
+  labs(y="posterior estimate of fire effect", x = "species code", title="Effect of fire on occurrence") +
+  theme_classic() +
+  scale_color_manual(values=wes_palette("BottleRocket1", n = 2)) +
+  theme(legend.position = "none", axis.text.x = element_text(angle = 50,hjust=1)) 
+
+
+### Interaction effect ------------------------------------------------------
+
+
+int <- out[241:288,]
+int$spp <- spp
+
+# fire.fx %>% filter(spp %in% tree.spp$spp) %>%
+#   mutate(updown = ifelse(mean>0,"up","down")) %>%
+ggplot(int) +
+  geom_point(aes(x=reorder(spp,-mean), y=mean, color=overlap0)) +
+  geom_errorbar(aes(x=reorder(spp,-mean), ymin=`2.5%`, ymax=`97.5%`, color=overlap0)) +
+  geom_linerange(size=2,aes(x=reorder(spp,-mean), ymin=`25%`, ymax=`75%`, color=overlap0)) +
+  geom_hline(yintercept = 0) +
+  labs(y="posterior estimate of interaction effect", x = "species code", title="Interaction of large trees x fire") +
+  theme_classic() +
+  scale_color_manual(values=wes_palette("BottleRocket1", n = 2)) +
+  theme(legend.position = "none", axis.text.x = element_text(angle = 50,hjust=1)) 
+
+
+# Trees x Fire Biplot [UNDER CONSTRUCTION] --------------------------------
+
+# colnames(trees) <- paste("tree", colnames(trees), sep = "_")
+# colnames(fire.fx) <- paste("fire", colnames(fire.fx), sep = "_")
+# 
+# d.biplot <- trees %>% 
+#   left_join(fire.fx, by=c("tree_spp" = "fire_spp"))
+# 
+# d.biplot$tree_fx[d.biplot$tree_mean < 0 & d.biplot$tree_overlap0==0] <- "negative"
+# d.biplot$tree_fx[d.biplot$tree_mean > 0 & d.biplot$tree_overlap0==0] ="positive" 
+# d.biplot$tree_fx[d.biplot$tree_overlap0==1] ="no effect" 
+# d.biplot$fire_fx[d.biplot$fire_mean < 0 & d.biplot$fire_overlap0==0] <- "negative"
+# d.biplot$fire_fx[d.biplot$fire_mean > 0 & d.biplot$fire_overlap0==0] ="positive" 
+# d.biplot$fire_fx[d.biplot$fire_overlap0==1] ="no effect" 
+# 
+# d.biplot <- d.biplot %>% mutate(sig = case_when(tree_overlap0==0 & fire_overlap0==0 ~ 4,
+#                          tree_overlap0==0 & fire_overlap0==1 ~ 3,
+#                          tree_overlap0==1 & fire_overlap0==0 ~ 2,
+#                          tree_overlap0==1 & fire_overlap0==1 ~ 1))
+#          
+# head(d.biplot)
+# rownames(d.biplot) <- d.biplot$tree_spp
+# 
+# ggplot(d.biplot, aes(x=tree_mean, y=fire_mean, color=as.factor(sig))) +
+#   geom_text(label=rownames(d.biplot), fontface="bold") +
+#   #geom_errorbar(aes(x=tree_mean, ymin=`fire_2.5%`, ymax=`fire_97.5%`, color=as.factor(sig))) +
+#   #geom_errorbar(aes(y=fire_mean, xmin=`tree_2.5%`, xmax=`tree_97.5%`, color=as.factor(sig), alpha=0.4)) +
+#   geom_hline(yintercept = 0) +
+#   geom_vline(xintercept = 0) +
+#   scale_colour_manual(values = c("azure4", "darkorange2", "forestgreen", "goldenrod3"),
+#                       labels = c("no effect", "effect of fire", "effect of trees", "effect of both"))  +
+#   labs(x="effect of large trees on occurrence", y= "effect of fire on occurrence intercept", color="parameter significance:") +
+#   theme_classic() +
+#   theme(legend.position = "top") -> biplot
+# biplot
+# 
+# bin.labs.f <- c("neg effect of fire", "pos effect of fire")
+# bin.labs.t <- c("neg effect of trees", "pos effect of trees")
+# names(bin.labs.f) <- c(-1,1)
+# names(bin.labs.t) <- c(-1,1)
+# 
+# biplot +
+#   facet_grid(fire_fx ~ tree_fx, labeller = labeller(tree_fx = bin.labs.t, 
+#                                                     fire_fx = bin.labs.f)) +
+#   theme_bw() +
+#   theme(legend.position="top")
+# 
+# # facet wrap by tree assn
+# ggplot(d.biplot) +
+#   geom_point(aes(x=reorder(spp,-fire_mean), y=fire_mean, color=fire_overlap0)) +
+#   geom_errorbar(aes(x=reorder(spp,-fire_mean), ymin=`fire_2.5%`, ymax=`fire_97.5%`, color=fire_overlap0)) +
+#   geom_linerange(size=2,aes(x=reorder(spp,-fire_mean), ymin=`fire_25%`, ymax=`fire_75%`, color=fire_overlap0)) +
+#   geom_hline(yintercept = 0) +
+#   labs(y="effect of fire on occurrence intercept", x = "species code", title="Effect of fire on occurrence, faceted by tree association") +
+#   theme_classic() +
+#   scale_color_manual(values=wes_palette("BottleRocket1", n = 2)) +
+#   theme(legend.position = "none", axis.text.x = element_text(angle = 50,hjust=1)) +
+#   facet_grid(tree_fx ~ .)
+# 
+# ggplot(d.biplot) +
+#   geom_point(aes(x=reorder(spp,-tree_mean), y=tree_mean, color=tree_overlap0)) +
+#   geom_errorbar(aes(x=reorder(spp,-tree_mean), ymin=`tree_2.5%`, ymax=`tree_97.5%`, color=tree_overlap0)) +
+#   geom_linerange(size=2,aes(x=reorder(spp,-tree_mean), ymin=`tree_25%`, ymax=`tree_75%`, color=tree_overlap0)) +
+#   geom_hline(yintercept = 0) +
+#   labs(y="posterior estimate of tree effect", x = "species code", title="Effect of trees on occurrence, faceted by fire response") +
+#   theme_classic() +
+#   scale_color_manual(values=wes_palette("BottleRocket1", n = 2)) +
+#   theme(legend.position = "none", axis.text.x = element_text(angle = 50,hjust=1)) +
+#   facet_grid(fire_fx ~ .)
+
+
+# Richness estimates ------------------------------------------------------
+# plot of mean sprich (Nsite) for burned vs unburned sites (by burn severity class?
+rich <- out[337:656,]
+rich$year <- as.vector(sapply(c("2018", "2019", "2020", "2021"), function(x) rep(x,80)))
+rich$site <- rep(siteList,4)
+rich$RAVG <- rep(Sev,4)
+rich$TallTree <- rep(Ht, 4)
+rich$TreeBin <- cut(rich$TallTree, breaks = c(-1, 0.02, 0.1, 0.2, 0.5))
+
+bin.labs <- c("0-2%", "2-10%", "11-20%", "20-50%")
+names(bin.labs) <- c("(-1,0.02]", "(0.02,0.1]","(0.1,0.2]", "(0.2,0.5]")
+
+ggplot(rich) +
+  geom_line(aes(x=year, y=mean, group=site, color=-RAVG)) +
+  facet_wrap(~TreeBin, labeller = labeller(TreeBin = bin.labs)) +
+  labs(y="posterior estimate of plot-level species richness", x = "year", title="Species Richness over time relative to large trees and burn severity") +
+  theme_classic() +
+  scale_color_gradient()
+
+unburned <- rich %>% filter(RAVG=="0") 
+ggplot(unburned) +
+  geom_line(aes(x=year, y=mean, group=site))
+
+# before and after betas
+BA <- out[1:96,]
+BA$spp <- as.vector(sapply(spp, function(x) rep(x,2)))
+BA$prepost <- rep(c("pre", "post"))
+
+pre <- BA %>% filter(prepost=="pre")
+post <- BA %>% filter(prepost=="post")
+post$firesig <- fire.fx$overlap0
+pre$firesig <- fire.fx$overlap0
+
+post2 <- post %>% filter(post$firesig=="0")
+pre2 <- pre %>% filter(pre$firesig=="0")
+
+# Posterior Predictions by Species -------------------------------------------------------------
+# create new design matrix with "new" covariates using identical scaling as our original data
+summary(data$Ht)
+o.tree <- seq(0,0.5,,500)
+
+summary(data$Cov)
+o.cov <- seq(-2.5, 1.75,,500)
+
+str(tmp <- BACI_z$sims.list)
+nsamp <- 4998
+nsamp
+
+### community mean occupancy predictions ------------------------------------
+# 
+# predC <- array(NA, dim = c(500,nsamp,6)) 
+# for (i in 1:nsamp) {
+#   predC[,i,1] <- plogis(tmp$b0[i] + tmp$bHt[i]*o.tree)
+#   predC[,i,2] <- plogis(tmp$b0[i] + tmp$bSev[i]*o.sev)
+#   predC[,i,3] <- plogis(tmp$b0[i] + tmp$bInt[i]*o.sev*o.tree)
+# }
+# 
+# head(predC)
+# pmC <- apply(predC, c(1,3), mean)
+# criC <- apply(predC, c(1,3), function(x) quantile(x, prob=c(0.025,0.975)))
+# 
+# plot(o.tree, pmC[,1], col="blue", lwd=3, type="l", lty=1, frame=F,
+#      ylim=c(0,1), xlab="% Large Trees", ylab="Community Mean Occupancy")
+# matlines(o.tree, t(criC[,,1]), col="grey", lty=1)
+# 
+# plot(o.sev, pmC[,2], col="blue", lwd=3, type="l", lty=1, frame=F,
+#      ylim=c(0,0.8), xlab="Fire Severity", ylab="Community Mean Occupancy")
+# matlines(o.sev, t(criC[,,2]), col="grey", lty=1)
+# 
+# pmC[,3]
+# head(pmC[,3])
+
+
+### species-specific predictions --------------------------------------------
+
+str(tmp) # this is the sims.list (or just the "naked" mcmc runs)
+tmp <- as.array(tmp)
+pm <- BACI_Out$mean
+cr.lo <- BACI_Out$q2.5
+cr.hi <- BACI_Out$q97.5
+head(pm)
+
+psi.coef <- cbind(pm$b0[1,], pm$b0[2,], pm$bHt, pm$bCov, pm$bInt, pm$effect.ba.sp) # setting it to b0[2] for the post-fire betas
+
+psi.cilo <- cbind(cr.lo$b0[1,], cr.lo$b0[2,], cr.lo$bHt, cr.lo$bCov, cr.lo$bInt, cr.lo$effect.ba.sp)
+
+psi.cihi <- cbind(cr.hi$b0[1,], cr.hi$b0[2,], cr.hi$bHt, cr.hi$bCov, cr.hi$bInt, cr.hi$effect.ba.sp)
+
+colnames(psi.coef) <- c("bBefore", "bAfter", "bHt", "bCov", "bInt", "bBACI")
+colnames(psi.cihi) <- c("bBefore", "bAfter", "bHt", "bCov", "bInt", "bBACI")
+colnames(psi.cilo) <- c("bBefore", "bAfter", "bHt", "bCov", "bInt", "bBACI")
+rownames(psi.coef) <- spp
+
+simHt <- o.tree
+simCov <- o.cov
+
+predS <- array(NA, dim=c(500,nspec,4))
+for(i in 1:nspec) {
+  predS[,i,1] <- plogis(psi.coef[i,1] + psi.coef[i,3]*simHt)
+  predS[,i,2] <- plogis(psi.coef[i,1] + psi.coef[i,4]*simCov)
+  predS[,i,3] <- plogis(psi.coef[i,1] + 
+                          psi.coef[i,3]*simHt + 
+                          psi.coef[i,4] +
+                          psi.coef[i,5]*simHt*1) # unburned
+  predS[,i,4] <- plogis(psi.coef[i,2] + 
+                          psi.coef[i,3]*simHt +
+                          psi.coef[i,4] +
+                          psi.coef[i,5]*simHt*2) # burned
+}
+
+plot(simHt, predS[,1,1], lwd=3, type="l", lty=1, frame=F, ylim= c(0,1), 
+     xlab="% Large Tree Cover", ylab = "Occupancy probability")
+for (i in 1:48) {
+  lines(simHt, predS[,i,1], col=i, lwd=3)
+}
+
+# BHGR
+plot(simHt, predS[,5,1], col="orange", lwd=3, type="l", lty=1, frame=F, ylim= c(0,1), 
+     xlab="% Large Tree Cover", ylab = "Occupancy probability", main="Black-headed Grosbeak")
+lines(simHt, predS[,5,3], col="forestgreen", lwd=3)
+lines(simHt, predS[,5,4], col="red", lwd=3)
+
+# GCKI
+plot(simHt, predS[,15,1], col="gray", lwd=3, type="l", lty=1, frame=F, ylim= c(0,1), 
+     xlab="% Large Tree Cover", ylab = "Occupancy probability", main="Golden-crowned Kinglet")
+lines(simHt, predS[,15,3], col="forestgreen", lwd=3)
+lines(simHt, predS[,15,4], col="red", lwd=3)
+
+# HETH
+plot(simHt, predS[,19,1], col="gray", lwd=3, type="l", lty=1, frame=F, ylim= c(0,1), 
+     xlab="% Large Tree Cover", ylab = "Occupancy probability", main="Hermit Thrush")
+lines(simHt, predS[,19,3], col="forestgreen", lwd=3)
+lines(simHt, predS[,19,4], col="red", lwd=3) 
+
+# psi exploration [UNDER CONSTRUCTION] ---------------------------------------------------------
+# not ready to run 
+# psi <- BACI_z$summary[15361:30720,]
+# p <- BACI_z$summary[30721:76801,]
+# z <- BACI_z$summary[1:15360,]
+# 
+# head(psi)
+# 
+# for (i in 1:psi.list) {
+#   psi.list$i$year <- rep(yearList, 48)
+# } 
+# 
+# # add species names
+# psi.list <- split(as.data.frame(psi), rep(1:80))
+# names(psi.list) <- siteList
+# psi$year <- as.vector(sapply(c("2018", "2019", "2020", "2021"), function(x) rep(x,80)))
+# rich$site <- rep(siteList,4)
+# # add sites
+# # add years

--- a/models/src/BACI_run.R
+++ b/models/src/BACI_run.R
@@ -1,0 +1,113 @@
+load("models/output/BACI_input.RData")
+library(tidyverse)
+library(chron)
+library(jagsUI)
+library(coda)
+library(lubridate)
+library(googledrive)
+library(here)
+library(data.table)
+library(reshape2)
+
+# BACI design modified from Cabodevilla et al. 2022
+
+cat("
+    model {
+    # i = species
+    # j = site
+    # k = visit
+    # t = year
+    
+    # OCCURRENCE PRIORS
+    mu.b0.before ~ dnorm(0, 0.5) # separate intercepts for before and after fire
+    mu.b0.after ~ dnorm(0, 0.5) 
+    tau.b0.spp ~ dgamma(0.1, 0.1)
+      
+    mu.bHt ~ dnorm(0,0.1)
+    tau.bHt ~ dgamma(0.1, 0.1)
+    
+    mu.bInt ~ dnorm(0,0.1)
+    tau.bInt ~ dgamma(0.1, 0.1)
+      
+    mu.bCov ~ dnorm(0,0.1)
+    tau.bCov ~ dgamma(0.1, 0.1)
+    
+    mu.bYr ~ dnorm(0, 0.1)
+    tau.bYr ~ dgamma(0.1, 0.1)
+    
+    # DETECTION PRIORS
+    mu.a0 ~ dnorm(0, 0.1) # intercept for detection model 
+    tau.a0 ~ dgamma(0.1, 0.1)
+    
+    mu.aT ~ dnorm(0,0.1)
+    tau.aT ~ dgamma(0.1, 0.1)
+      
+    mu.aD ~ dnorm(0,0.1)
+    tau.aD ~ dgamma(0.1, 0.1)
+    
+    for (i in 1:nspec) {
+    
+        b0[1,i] ~ dnorm(mu.b0.before, tau.b0.spp)
+        b0[2,i] ~ dnorm(mu.b0.after, tau.b0.spp)
+        bHt[i] ~ dnorm(mu.bHt, tau.bHt)
+        bCov[i] ~ dnorm(mu.bCov, tau.bCov)
+        bInt[i] ~ dnorm(mu.bInt, tau.bInt)
+        bYr[i] ~ dnorm(mu.bYr, tau.bYr)
+
+        a0[i] ~ dnorm(mu.a0, tau.a0)
+        aTime[i] ~ dnorm(mu.aT, tau.aT)
+        aDate[i] ~ dnorm(mu.aD, tau.aD)
+    
+      for (j in 1:nsite) {
+      
+        for (t in 1:nyear) {
+      
+          logit(psi[j,t,i]) <- b0[BACI[j,t]+1,i] + bHt[i]*Ht[j] + bCov[i]*Cov[j] +bInt[i]*BACI[j,4]+1*Ht[j] + bYr[i]*t
+          z[j,t,i] ~ dbern(psi[j,t,i])
+          
+          for (k in 1:nsurvey) {
+                
+            mu.y[j,k,t,i] <- p[j,k,t,i] * z[j,t,i] 
+            y[j,k,t,i] ~ dbern(mu.y[j,k,t,i])  
+            logit(p[j,k,t,i]) <- a0[i] + aTime[i]*Time[j,k,t] + aDate[i]*Date[j,k,t]
+                
+                } #k
+            } #t
+        } #j
+    } #i
+    
+    # Derived Quantities
+      # effect of before/after
+      for (i in 1:nspec) {
+      effect.ba.sp[i] <- b0[2,i] - b0[1,i]
+      }
+      # species richness at each site/year
+      for (j in 1:nsite) {
+        for (t in 1:nyear) {
+          Nsite[j,t] <- sum(z[j,t,])
+      }
+      }
+    
+    } # end of model loop
+    ", file ="models/jags/BACI_occupancy.txt") 
+
+# params + run ------------------------------------------------------------
+params <- c( # I have to run z, psi, and p individually in separate runs or my computer crashes
+ # "a0", "aTime", "aDate",
+  "b0", "bYr", "bCov", "bHt", "bInt",
+  "effect.ba.sp", "Nsite"
+ # "z", "psi", "p"
+  )
+
+# initial values
+zst <- apply(y,c(1,3,4),max,na.rm=TRUE)  
+
+inits <- function(){list(z = zst)} #these are initial values for jags to start looking for estimates
+
+BACI_Out <- jags(data = data, model.file = "models/jags/BACI_occupancy.txt", inits=inits, parameters.to.save = params, n.chains = 3, n.iter = 10000, n.burnin = 5000, n.thin = 3) 
+
+out <- as.data.frame(BACI_Out$summary[1:657,]) # check length of summary before saving 
+out$overlap0 <- as.factor(out$overlap0)
+write_csv(out, "models/output/BACI_out.csv")
+
+save(BACI_Out, out, data, BACI, siteList, Ht, spp, file = "models/output/BACIdata.RData") # need to git ignore this

--- a/models/src/BACI_setup.R
+++ b/models/src/BACI_setup.R
@@ -1,0 +1,155 @@
+# Libraries ---------------------------------------------------------------
+
+library(tidyverse)
+library(chron)
+library(jagsUI)
+library(coda)
+library(lubridate)
+library(googledrive)
+library(here)
+library(data.table)
+library(reshape2)
+
+source(here("caples_functions.R"))
+
+# Read in data ------------------------------------------------------------
+
+if (dir.exists(here("models/jags/")) == FALSE) {
+  dir.create(here("models/jags"))
+}
+if (dir.exists(here("models/output/")) == FALSE) {
+  dir.create(here("models/output"))
+}
+
+# TODO []: link to Google Drive &/or a link to `read_PC.R`. The Google Drive code in readPC.R does not work when using non-CalAcademy login. For now, doing a hard download.
+
+# TODO []: why does the total # of entries differ from that in the Caples git?
+
+PC <- fread(here("point_counts/data_ingest/output/PC_delinted.csv"))
+PC <- PC %>% filter(visit<4)
+visits <- PC %>%
+  group_by(point_ID_fk, year, DateTime) %>%
+  summarise(rich = n_distinct(birdCode_fk)) %>%
+  arrange(DateTime, .by_group = TRUE) %>%
+  mutate(visit = seq_along(DateTime))
+
+extraVisits <- visits %>% filter(visit > 3)
+
+birdTots <- PC %>% group_by(birdCode_fk) %>% summarise(tot = sum(abun)) %>% filter(tot>3)
+dfc <- PC %>% filter(birdCode_fk %in% birdTots$birdCode_fk)
+
+nsite <- length(unique(dfc$point_ID_fk))
+nvisit <- length(unique(dfc$visit))
+nyear <- length(unique(dfc$year))
+nspec <- length(unique(dfc$birdCode_fk))
+
+y <- melt(dfc, id.var = c("birdCode_fk", "point_ID_fk", "visit", "yr"), measure.var = "abun") %>% acast(point_ID_fk ~ visit ~ yr ~ birdCode_fk)
+
+# COVARIATES
+
+dates1 <- visits %>%
+  dplyr::select(-rich) %>%
+  filter(visit < 4) %>%
+  mutate(JDay = as.numeric(format(DateTime, "%j"))) %>%
+  select(-DateTime) %>%
+  melt(id.var = c("point_ID_fk", "year", "visit"), measure.var = "JDay") %>%
+  acast(point_ID_fk ~ visit ~ year)
+
+# standardize dates
+mdate <- mean(dates1, na.rm = TRUE)
+sddate <- sqrt(var(dates1[1:length(dates1)], na.rm = TRUE))
+date1 <- (dates1 - mdate) / sddate
+
+date1[is.na(date1)] <- 0
+
+# TIME matrix [under construction - issue with time zone and converting to list of matrices]
+
+times <- visits %>%
+  dplyr::select(-rich) %>%
+  filter(visit < 4) %>%
+  mutate(Time = as.numeric(times(format(DateTime, "%H:%M:%S")))) %>%
+  select(-DateTime) %>%
+  melt(id.var = c("point_ID_fk", "year", "visit"), measure.var = "Time") %>%
+  acast(point_ID_fk ~ visit ~ year)
+
+# standardize times
+mtime <- mean(times, na.rm = TRUE)
+sdtime <- sqrt(var(times[1:length(times)], na.rm = TRUE))
+time1 <- (times - mtime) / sdtime
+
+time1[is.na(time1)] <- 0
+
+# [] TODO: update with google drive links &/or symlinks
+
+newEnv1 <- read_csv("data/wide1havars.csv")
+newEnv4 <- read_csv("data/wide4havars.csv")
+tallvars <- read_csv("data/tallvars.csv")
+
+utms <- read_csv("data/Wildlife_Sampling_Points.csv")
+head(newEnv1)
+
+prefire <- newEnv1 %>%
+  dplyr::select(point_d, Perc_LargeTreeG22mHeight_2018_1ha, mean_CanopyCover_2018_1ha, max_Elevation_NA_1ha, mean_Caples_dNBR_Nov18_Nov19_1ha) %>%
+  left_join(utms, by = c("point_d" = "point_id")) %>%
+  arrange(point_d)
+
+prefire4 <- newEnv4 %>%
+  dplyr::select(point_d, Perc_LargeTreeG22mHeight_2018_4ha, mean_CanopyCover_2018_4ha, max_Elevation_NA_4ha, mean_Caples_dNBR_Nov18_Nov19_4ha, mean_RAVGcbi4_20182019_4ha) %>%
+  left_join(utms, by = c("point_d" = "point_id")) %>%
+  arrange(point_d)
+
+prefire4$RAVG = cut(prefire4$mean_RAVGcbi4_20182019_4ha, breaks = c(-1, 0.5, 2, 3, 4), labels=c(0,1,2,3))
+
+siteList <- sort(unique(dfc$point_ID_fk))
+
+setdiff(prefire4$point_d, siteList) # these three aren't point count locations
+setdiff(siteList, prefire4$point_d) # 1072 is missing in the metadata for some reason
+
+siteData4 <- prefire4 %>%
+  filter(point_d %in% unique(visits$point_ID_fk)) %>%
+  separate(SZ_DNS2, c("Size", "Density"), sep = 1)
+
+siteData4 %>% ggplot() +
+  geom_boxplot(aes(x=RAVG, y=mean_Caples_dNBR_Nov18_Nov19_4ha))
+
+Cover <- scale(siteData4$mean_CanopyCover_2018_4ha)
+Ht <- siteData4$Perc_LargeTreeG22mHeight_2018_4ha
+El <- scale(siteData4$max_Elevation_NA_4ha)
+Sev <- as.numeric(as.character(siteData4$RAVG))
+
+BA <- matrix(NA, nsite, nyear)
+#colnames(BA) <- 2018:2021
+#rownames(BA) <- siteList
+BA[,1:2] <- 0
+BA[,3:4] <- 1
+
+BACI <- BA*Sev
+BACI[BACI>0] <- 1
+
+
+spp <- unique(dfc$birdCode_fk)
+
+occ <- 1
+if (occ == 1) {
+  y[y > 0] <- 1
+} else {
+  y <- y
+}
+
+data <- list(
+  nspec = nspec, # number of species (integer)
+  nsite = nsite, # number of sites (integer)
+  nsurvey = 3, # number of visits to each site
+  nyear = nyear, # number of years (integer)
+  y = y, # 4D array of detection/nondetection data
+  Time = time1, # 3D array of standardized times [nsite x nsurvey x nyear]
+  Date = date1,
+  Ht = as.vector(Ht),
+  Cov = as.vector(Cover),
+  BACI = BACI
+  #dNBR = as.vector(dNBR)
+  # and any other variables we'd want in either part of the model (aspect, etc... but just starting with these for now)
+)
+
+save(data, Ht, Cover, BACI, Sev, siteList, spp, file = "models/output/BACI_input.RData") # need to git ignore this
+load("models/output/BACI_input.RData")


### PR DESCRIPTION
These three scripts read in point count data, specify and run a JAGS model, and begin to explore the output of a Point-Count-data-only, pre-post fire model. Bugs exist that I will make separate issues for:

[] figure out why the number of entries in the PC dataframe is different here than in the version on the Caples git
[] fix the path to the SALO data (using a link to Google Drive, or a symlink to a git.ignored file 
[] confirm the directory to which JAGS outputs are written is correct