### PR TITLE
fixed_drive_sync for folders

### DIFF
--- a/comb_functions.R
+++ b/comb_functions.R
@@ -120,7 +120,14 @@ drive_sync <- function(local_dir, drive_folder, pattern = NULL) {
     google_files <- drive_ls(as_dribble(drive_folder)) %>%
       filter(str_detect(name, pattern = pattern))
   }
-
+  
+  # fixing part where it tries to download folders (which throws an error)
+  google_files <- google_files %>% 
+    filter(
+      unlist(map(1:length(google_files$drive_resource), 
+                 ~ google_files$drive_resource[[.x]][["mimeType"]] != "application/vnd.google-apps.folder"))
+    )
+  
   if (is.null(pattern) == TRUE) {
     local_files <- basename(system(paste0("find ", local_dir, " -mindepth 1 -maxdepth 1 ! -type l"), intern = TRUE))
   } else {


### PR DESCRIPTION
This will make sure that `drive_sync` does not attempt to download folders which throws an error